### PR TITLE
add --no-shares-stat option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,18 +4,19 @@ import fs = require('fs');
 import size_tree = require('./size_tree');
 import webpack_stats = require('./webpack_stats');
 
-function printStats(json: string, outputAsJson: boolean) {
+function printStats(json: string, opts: { outputAsJson: boolean, sharesStat: boolean }) {
     const bundleStats = JSON.parse(json) as webpack_stats.WebpackStats;
 	const depTrees = size_tree.dependencySizeTree(bundleStats);
-    if (outputAsJson) {
+    if (opts.outputAsJson) {
         console.log(JSON.stringify(depTrees, undefined, 2));
     } else {
-        depTrees.forEach(tree => size_tree.printDependencySizeTree(tree));
+        depTrees.forEach(tree => size_tree.printDependencySizeTree(tree, opts.sharesStat));
     }
 }
 
 commander.version('1.1.0')
          .option('-j --json', 'Output as JSON')
+         .option('--no-shares-stat', 'Suppress shares stat from output')
          .usage('[options] [Webpack JSON output]')
          .description(
  `Analyzes the JSON output from 'webpack --json'
@@ -30,14 +31,17 @@ commander.version('1.1.0')
 commander.parse(process.argv);
 
 
-const outputAsJson = commander['json'];
+const opts = {
+	outputAsJson: commander['json'],
+	sharesStat:   commander['sharesStat']
+}
 
 if (commander.args[0]) {
-	printStats(fs.readFileSync(commander.args[0]).toString(), outputAsJson);
+	printStats(fs.readFileSync(commander.args[0]).toString(), opts);
 } else if (!process.stdin.isTTY) {
 	let json = '';
 	process.stdin.on('data', (chunk: any) => json += chunk.toString());
-	process.stdin.on('end', () => printStats(json, outputAsJson));
+	process.stdin.on('end', () => printStats(json, opts));
 } else {
 	console.error('No Webpack JSON output file specified. Use `webpack --json` to generate it.');
 	process.exit(1);

--- a/src/size_tree.ts
+++ b/src/size_tree.ts
@@ -30,7 +30,7 @@ export interface RootStatsNode extends StatsNode {
   * size contributed to the bundle by each package's own code plus those
   * of its dependencies.
   */
-export function printDependencySizeTree(node: StatsNode, depth: number = 0,
+export function printDependencySizeTree(node: StatsNode, sharesStat: boolean, depth: number = 0,
   outputFn: (str: string) => void = console.log) {
 
 	if (node.hasOwnProperty('bundleName')) {
@@ -53,10 +53,14 @@ export function printDependencySizeTree(node: StatsNode, depth: number = 0,
 
 	for (const child of childrenBySize) {
 		++includedCount;
-		const percentage = ((child.size/totalSize) * 100).toPrecision(3);
-		outputFn(`${prefix}${child.packageName}: ${filesize(child.size)} (${percentage}%)`);
+		let out = `${prefix}${child.packageName}: ${filesize(child.size)}`;
+		if (sharesStat) {
+			const percentage = ((child.size/totalSize) * 100).toPrecision(3);
+			out = `${out} (${percentage}%)`;
+		}
+		outputFn(out);
 	
-		printDependencySizeTree(child, depth + 1, outputFn);
+		printDependencySizeTree(child, sharesStat, depth + 1, outputFn);
 
 		remainder -= child.size;
 
@@ -66,8 +70,12 @@ export function printDependencySizeTree(node: StatsNode, depth: number = 0,
 	}
 
 	if (depth === 0 || remainder !== totalSize) {
-		const percentage = ((remainder/totalSize) * 100).toPrecision(3);
-		outputFn(`${prefix}<self>: ${filesize(remainder)} (${percentage}%)`);
+		let out = `${prefix}<self>: ${filesize(remainder)}`;
+		if (sharesStat) {
+			const percentage = ((remainder/totalSize) * 100).toPrecision(3);
+			out = `${out} (${percentage}%)`
+		}
+		outputFn(out);
 	}
 }
 


### PR DESCRIPTION
added option `--no-shares-stat`

I am calculating metrics for each PR, commit it, and see its diff during code review.
Shares stat like `(15.12%)` produces to verbose diffs on any change of code. I'd like to see diff only when actual file size is changed.